### PR TITLE
Change wording (consistency)

### DIFF
--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -61,11 +61,11 @@
     'settings'        => [
         'cookies'        => [
             'label' => 'Cookies',
-            'description' => 'Gestion des cookies',
+            'description' => 'Configurer les cookies utilisés par le site et leur contrôle.',
         ],
         'cookie_consent' => [
-            'label'                     => 'Cookie de consentement',
-            'description'               => 'Réglages pour Klaro! Manager',
+            'label'                     => 'Composant Klaro!',
+            'description'               => 'Réglages gestionnaire de consentement Klaro!',
             'cookie_expires_after_days' => [
                 'label'   => 'Durée de vie des cookies en jours',
                 'comment' => 'Les réglages de l\'utilisateur sont conservés pendant ce nombre de jours.',


### PR DESCRIPTION
Change in the administrator menu to better differentiate the settings of the cookie manager and those of the Klaro! consent manager.