### PR TITLE
remove trans() method from ML key declarations

### DIFF
--- a/classes/cleanup/CleanupService.php
+++ b/classes/cleanup/CleanupService.php
@@ -123,7 +123,7 @@ class CleanupService
     public function getKeepDays()
     {
         return [
-            'label' => trans('offline.gdpr::lang.settings.data_retention.keep_days.label'),
+            'label' => 'offline.gdpr::lang.settings.data_retention.keep_days.label',
             'span'  => 'auto',
             'type'  => 'number',
             'tab'   => 'Plugins',

--- a/components/ConsentManager.php
+++ b/components/ConsentManager.php
@@ -20,7 +20,7 @@ class ConsentManager extends ComponentBase
     {
         return [
             'name'        => 'Klaro! Consent Manager',
-            'description' => trans('offline.gdpr::lang.consent_manager.description'),
+            'description' => 'offline.gdpr::lang.consent_manager.description',
         ];
     }
 
@@ -28,14 +28,14 @@ class ConsentManager extends ComponentBase
     {
         return [
             'include_assets' => [
-                'title'       => trans('offline.gdpr::lang.consent_manager.include_assets.title'),
-                'description' => trans('offline.gdpr::lang.consent_manager.include_assets.description'),
+                'title'       => 'offline.gdpr::lang.consent_manager.include_assets.title',
+                'description' => 'offline.gdpr::lang.consent_manager.include_assets.description',
                 'default'     => 1,
                 'type'        => 'checkbox',
             ],
             'style_prefix' => [
-                'title'       => trans('offline.gdpr::lang.consent_manager.style_prefix.title'),
-                'description' => trans('offline.gdpr::lang.consent_manager.style_prefix.description'),
+                'title'       => 'offline.gdpr::lang.consent_manager.style_prefix.title',
+                'description' => 'offline.gdpr::lang.consent_manager.style_prefix.description',
                 'type'        => 'string',
             ],
         ];

--- a/components/CookieBanner.php
+++ b/components/CookieBanner.php
@@ -23,7 +23,7 @@ class CookieBanner extends ComponentBase
     {
         return [
             'name'        => 'Cookie Banner',
-            'description' => trans('offline.gdpr::lang.cookie_banner.description'),
+            'description' => 'offline.gdpr::lang.cookie_banner.description',
         ];
     }
 
@@ -31,36 +31,36 @@ class CookieBanner extends ComponentBase
     {
         return [
             'include_css'         => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.include_css.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.include_css.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.include_css.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.include_css.description',
                 'default'     => 1,
                 'type'        => 'checkbox',
             ],
             'hard_reload'         => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.hard_reload.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.hard_reload.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.hard_reload.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.hard_reload.description',
                 'default'     => 0,
                 'type'        => 'checkbox',
             ],
             'update_partial'      => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.update_partial.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.update_partial.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.update_partial.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.update_partial.description',
                 'type'        => 'string',
             ],
             'update_selector'     => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.update_selector.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.update_selector.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.update_selector.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.update_selector.description',
                 'default'     => '#gdpr-reload',
                 'type'        => 'string',
             ],
             'cookie_manager_page' => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.cookie_manager_page.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.cookie_manager_page.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.cookie_manager_page.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.cookie_manager_page.description',
                 'type'        => 'dropdown',
             ],
             'ignore_behaviour'    => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.ignore_behaviour.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.ignore_behaviour.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.ignore_behaviour.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.ignore_behaviour.description',
                 'type'        => 'dropdown',
             ],
         ];
@@ -162,9 +162,9 @@ class CookieBanner extends ComponentBase
     public function getIgnore_behaviourOptions()
     {
         return [
-            'nothing' => trans('offline.gdpr::lang.cookie_banner.ignore_behaviour.nothing'),
-            'opt-in'  => trans('offline.gdpr::lang.cookie_banner.ignore_behaviour.opt-in'),
-            'opt-out' => trans('offline.gdpr::lang.cookie_banner.ignore_behaviour.opt-out'),
+            'nothing' => 'offline.gdpr::lang.cookie_banner.ignore_behaviour.nothing',
+            'opt-in'  => 'offline.gdpr::lang.cookie_banner.ignore_behaviour.opt-in',
+            'opt-out' => 'offline.gdpr::lang.cookie_banner.ignore_behaviour.opt-out',
         ];
     }
 }

--- a/components/CookieManager.php
+++ b/components/CookieManager.php
@@ -18,7 +18,7 @@ class CookieManager extends ComponentBase
     {
         return [
             'name'        => 'Cookie Manager',
-            'description' => trans('offline.gdpr::lang.cookie_manager.description'),
+            'description' => 'offline.gdpr::lang.cookie_manager.description',
         ];
     }
 
@@ -26,8 +26,8 @@ class CookieManager extends ComponentBase
     {
         return [
             'include_css' => [
-                'title'       => trans('offline.gdpr::lang.cookie_banner.include_css.title'),
-                'description' => trans('offline.gdpr::lang.cookie_banner.include_css.description'),
+                'title'       => 'offline.gdpr::lang.cookie_banner.include_css.title',
+                'description' => 'offline.gdpr::lang.cookie_banner.include_css.description',
                 'default'     => 1,
                 'type'        => 'checkbox',
             ],


### PR DESCRIPTION
The framework automatically checks for translatable strings when parsing the code. Therefor the trans() method is not necessary.

Not sure if there are any more link, or if you have done this for a specific reason though