### PR TITLE
remove prefix from plugin icon

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2,7 +2,7 @@ plugin:
     name: 'offline.gdpr::lang.plugin.name'
     description: 'offline.gdpr::lang.plugin.description'
     author: OFFLINE
-    icon: oc-icon-gavel
+    icon: icon-gavel
     homepage: 'https://github.com/OFFLINE-GmbH/oc-gdpr-plugin'
 permissions:
     offline.gdpr.manage_cookie_consent:


### PR DESCRIPTION
The plugin icon is prefixed by "oc". While this works for top-level plugin listing, the components don't have any icons in the "puzzle view".