### PR TITLE
Prevent type error on Cookie model

### DIFF
--- a/models/Cookie.php
+++ b/models/Cookie.php
@@ -71,7 +71,7 @@ class Cookie extends Model
 
                 return $level;
             }
-            if ($level['is_default_level']) {
+            if (is_array($level['is_default_level']) && $level['is_default_level']) {
                 $hasDefault = true;
             }
 


### PR DESCRIPTION
I got a type error with the following line. I applied this change locally, and may it's helpful to share it.

PHP 8.0.19


```
[2022-05-18 19:54:28] local.ERROR: Symfony\Component\Debug\Exception\FatalThrowableError: Cannot access offset of type string on string in /Users/renick/x/stage/plugins/offline/gdpr/models/Cookie.php:74
Stack trace:
#0 [internal function]: OFFLINE\GDPR\Models\Cookie->OFFLINE\GDPR\Models\{closure}('', 0)
#1 /Users/renick/x/stage/vendor/laravel/framework/src/Illuminate/Support/Collection.php(638): array_map(Object(Closure), Array, Array)
#2 /Users/renick/x/stage/plugins/offline/gdpr/models/Cookie.php(79): Illuminate\Support\Collection->map(Object(Closure))
#3 /Users/renick/x/stage/plugins/offline/gdpr/models/Cookie.php(55): OFFLINE\GDPR\Models\Cookie->enforceSingleDefaultLevel()
#4 /Users/renick/x/stage/vendor/october/rain/src/Events/Dispatcher.php(388): OFFLINE\GDPR\Models\Cookie::OFFLINE\GDPR\Models\{closure}(Object(OFFLINE\GDPR\Models\Cookie))
#5 /Users/renick/x/stage/vendor/october/rain/src/Events/Dispatcher.php(234): October\Rain\Events\Dispatcher->October\Rain\Events\{closure}('eloquent.saving...', Array)
#6 /Users/renick/x/stage/vendor/october/rain/src/Events/Dispatcher.php(189): October\Rain\Events\Dispatcher->dispatch('eloquent.saving...', Array, true)
#7 /Users/renick/x/stage/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Concerns/HasEvents.php(189): October\Rain\Events\Dispatcher->until('eloquent.saving...', Object(OFFLINE\GDPR\Models\Cookie))
#8 /Users/renick/x/stage/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(652): Illuminate\Database\Eloquent\Model->fireModelEvent('saving')
#9 /Users/renick/x/stage/vendor/october/rain/src/Database/Model.php(780): Illuminate\Database\Eloquent\Model->save(Array)
#10 /Users/renick/x/stage/vendor/october/rain/src/Database/Model.php(814): October\Rain\Database\Model->saveInternal(Array)
```
